### PR TITLE
Remove swift support plugin

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -5,8 +5,6 @@
         <clobbers target="cordova.plugins.SiriShortcuts" />
     </js-module>
 
-    <dependency id="cordova-plugin-add-swift-support" version="1.7.2"/>
-
     <platform name="ios">
         <config-file target="config.xml" parent="/*">
             <feature name="SiriShortcuts">


### PR DESCRIPTION
Recent versions of cordova-ios (>=5) don't need this plugin anymore