### PR TITLE
do not donate shortcuts in background thread

### DIFF
--- a/src/ios/SiriShortcuts.swift
+++ b/src/ios/SiriShortcuts.swift
@@ -15,19 +15,17 @@ import IntentsUI
     }
 
     @objc(donate:) func donate(_ command: CDVInvokedUrlCommand) {
-        self.commandDelegate!.run(inBackground: {
-            if #available(iOS 12.0, *) {
-                self.activity = self.createUserActivity(from: command, makeActive: true)
+        if #available(iOS 12.0, *) {
+            self.activity = self.createUserActivity(from: command, makeActive: true)
 
-                // tell Cordova we're all OK
-                self.sendStatusOk(command)
+            // tell Cordova we're all OK
+            self.sendStatusOk(command)
 
-                return
-            }
+            return
+        }
 
-            // shortcut not donated
-            self.sendStatusError(command)
-        })
+        // shortcut not donated
+        self.sendStatusError(command)
     }
 
     @objc(present:) func present(_ command: CDVInvokedUrlCommand) {


### PR DESCRIPTION
Fixes "UI API called on a background thread" error. `setUserActivity` cannot be called in a background thread.